### PR TITLE
Update deprecated syntax for future rstan compatibility 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     Rcpp,
     RcppParallel (>= 5.0.1),
     methods,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.0.0),
     stats,
     utils
@@ -44,8 +44,8 @@ LinkingTo:
     Rcpp (>= 0.12.15),
     RcppEigen (>= 0.3.3.4.0),
     RcppParallel (>= 5.0.1),
-    StanHeaders (>= 2.21.0),
-    rstan (>= 2.18.1)
+    StanHeaders (>= 2.26.0),
+    rstan (>= 2.26.0)
 Suggests:
     testthat (>= 2.1.0)
 ByteCompile: yes

--- a/inst/stan/base0_logit.stan
+++ b/inst/stan/base0_logit.stan
@@ -17,7 +17,7 @@ data {
   matrix[N, U] X;
 
   // binary response variable
-  int<lower=0, upper=1> y[N];
+  array[N] int<lower=0, upper=1> y;
 }
 
 parameters {

--- a/inst/stan/hs_logit.stan
+++ b/inst/stan/hs_logit.stan
@@ -26,7 +26,7 @@ data {
   matrix[N, P] X;
 
   // binary response variable
-  int<lower=0, upper=1> y[N];
+  array[N] int<lower=0, upper=1> y;
 
   // prior standard deviation for the unpenalised variables
   real<lower=0> scale_u;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
